### PR TITLE
Change default serial device to '/dev/serial0' for compatibility with RPi Zero W and Rpi 3.

### DIFF
--- a/serial_fpga/sw/serial_fpga.c
+++ b/serial_fpga/sw/serial_fpga.c
@@ -4,7 +4,7 @@
  *  Description: Simple interface to a Linux serial port
  *
  *  Resources:
- *    port   -  full path to serial port (/dev/ttyAMA0)
+ *    port   -  full path to serial port (/dev/serial0)
  *    config -  baudrate in range of 1200 to 921000
  *    intrr_pin -  which pin to monitor as an interrupt
  *    rawin  -  Received characters displayed in hex
@@ -62,7 +62,7 @@
         // What we are is a ...
 #define PLUGIN_NAME        "serial_fpga"
         // Default serial port
-#define DEFDEV             "/dev/ttyAMA0"
+#define DEFDEV             "/dev/serial0"
         // Default baudrate
 #define DEFBAUD            115200
         // Interrupt status register


### PR DESCRIPTION
These RPi models swap the usage of the SOP's hardware UARTs /dev/ttyAMA0 and /dev/ttyS0, which breaks applications that refer to the physical device names.

Newer versions of the kernel create /dev/serial* functional device names for comp[atability across all hardware versions.

/dev/serial0 always refers to the primary UART, which is connected to header pins TXD0 and RXD0, and to the Serial FPGA.

This change should allow the daemon to function propery, with defaults, on all hardware models.

- See...  https://www.raspberrypi.org/documentation/configuration/uart.md

